### PR TITLE
Add support for sending events

### DIFF
--- a/PrimusEmitter/PrimusEmitter.h
+++ b/PrimusEmitter/PrimusEmitter.h
@@ -15,6 +15,12 @@ typedef NS_ENUM(NSInteger, PrimusPacketType) {
     kPrimusPacketTypeAck
 };
 
+@interface Primus (Emitter)
+
+- (void)send:(NSString *)event data:(id)data;
+
+@end
+
 @interface PrimusEmitter : NSObject<PluginProtocol>
 {
     NSObject<PrimusProtocol> * __unsafe_unretained _primus;

--- a/PrimusEmitter/PrimusEmitter.m
+++ b/PrimusEmitter/PrimusEmitter.m
@@ -6,7 +6,21 @@
 //  Copyright (c) 2014 Seegno. All rights reserved.
 //
 
+#import <Primus/Primus.h>
+
 #import "PrimusEmitter.h"
+
+@implementation Primus (Emitter)
+
+- (void)send:(NSString *)event data:(id)data
+{
+    [self write:@{
+        @"type": @(kPrimusPacketTypeEvent),
+        @"data": @[event, data]
+    }];
+}
+
+@end
 
 @implementation PrimusEmitter
 

--- a/PrimusEmitterTests/PrimusEmitterTest.m
+++ b/PrimusEmitterTests/PrimusEmitterTest.m
@@ -35,6 +35,21 @@ describe(@"Primus-Emitter", ^{
     });
 
     it(@"should emit event", ^AsyncBlock {
+        [primus on:@"outgoing::data" listener:^(NSData *data) {
+            NSDictionary *packet = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
+
+            expect(packet[@"type"]).to.equal(@(kPrimusPacketTypeEvent));
+            expect(packet[@"data"]).to.equal(@[@"news", @"hello"]);
+
+            done();
+        }];
+
+        [primus emit:@"incoming::open"];
+
+        [primus send:@"news" data:@"hello"];
+    });
+
+    it(@"should support strings", ^AsyncBlock {
         [primus on:@"news" listener:^(id data) {
             expect(data).to.equal(@"hello");
 
@@ -47,7 +62,7 @@ describe(@"Primus-Emitter", ^{
         }];
     });
 
-    it(@"should emit object", ^AsyncBlock {
+    it(@"should support objects", ^AsyncBlock {
         NSDictionary *object = @{ @"hi": @"hello", @"num": @(123456) };
 
         [primus on:@"news" listener:^(id data) {


### PR DESCRIPTION
This PR adds a `send` method to the _Primus_ object by way of a category.

Feedback is welcome.

Closes #1.
